### PR TITLE
feat: make Docker build self-contained for backend

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -7,11 +7,22 @@ FROM node:20-alpine AS builder
 # Install build tools needed for better-sqlite3 native compilation
 RUN apk add --no-cache python3 make g++
 
-WORKDIR /app/backend
+WORKDIR /app
 
-# Copy package files and install dependencies
-COPY backend/package*.json ./
-RUN npm ci --production
+# Copy package files and install ALL dependencies (including dev dependencies for building)
+COPY package*.json ./
+COPY backend/package*.json ./backend/
+RUN cd backend && npm ci
+
+# Copy source code and shared directory
+COPY backend/ ./backend/
+COPY shared/ ./shared/
+
+# Create a simple tsconfig for Docker build
+RUN echo '{"compilerOptions": {"target": "ES2022", "module": "commonjs", "lib": ["ES2022"], "outDir": "./backend/dist", "strict": true, "esModuleInterop": true, "skipLibCheck": true, "forceConsistentCasingInFileNames": true, "resolveJsonModule": true, "moduleResolution": "node", "declaration": true, "declarationMap": true, "sourceMap": true}, "include": ["backend/src/**/*", "shared/**/*"], "exclude": ["**/node_modules", "**/dist", "**/*.test.ts"]}' > tsconfig.docker.json
+
+# Build the TypeScript code from project root
+RUN ./backend/node_modules/.bin/tsc --project tsconfig.docker.json
 
 # Stage 2: Production image (without build tools)
 FROM node:20-alpine


### PR DESCRIPTION
- Modify Dockerfile.backend to include TypeScript compilation within Docker build
- Install all dependencies (including dev dependencies) in builder stage
- Copy source code and shared directory for compilation
- Create Docker-specific tsconfig.json optimized for container build
- Build TypeScript code during Docker build instead of requiring pre-build
- Eliminates need for local backend build before running docker-compose

This makes the docker-compose.demo.yml workflow completely self-contained, requiring only `docker-compose up` without any manual build steps.

Task Completed

-------
PR test

## ✅ PR Testing Results

__Testing completed from scratch:__

- ✅ Docker build successful
- ✅ Both backend and frontend containers running
- ✅ Backend API responding at `http://localhost:3001/health`
- ✅ Frontend serving at `http://localhost:3000`

__Key improvements verified:__

- __Self-contained build__: No manual `npm run build:backend` required
- __Clean Docker workflow__: Just `docker-compose -f docker-compose.demo.yml up`
- __TypeScript compilation__: Happens automatically within Docker
- __All dependencies__: Properly installed and copied

The PR successfully makes the Docker setup completely self-contained, eliminating the build dependency issue you originally encountered. Users can now clone the repo, checkout the branch, and run `docker-compose up` without any additional build steps.
