### PR TITLE
Increase priority limit from 1000 to 10000

### DIFF
--- a/backend/src/api/problems.test.ts
+++ b/backend/src/api/problems.test.ts
@@ -334,7 +334,41 @@ describe('Problems API', () => {
         .send({ priority: 'not-a-number' });
       
       expect(response.status).toBe(400);
-      expect(response.body.error).toBe('Priority must be a number between 0 and 1000');
+      expect(response.body.error).toBe('Priority must be a number');
+    });
+
+    it('should reject priority greater than 10000', async () => {
+      const problemRepo = getProblemRepository(prisma);
+      const created = await problemRepo.create({
+        workspaceId,
+        organizationId,
+        problem: 'Test problem',
+        objective: 'Test objective',
+      });
+
+      const response = await request(app)
+        .patch(`/api/problems/${created.id}`)
+        .send({ priority: 10001 });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Priority must be a number between 0 and 10000');
+    });
+
+    it('should accept priority up to 10000', async () => {
+      const problemRepo = getProblemRepository(prisma);
+      const created = await problemRepo.create({
+        workspaceId,
+        organizationId,
+        problem: 'Test problem',
+        objective: 'Test objective',
+      });
+
+      const response = await request(app)
+        .patch(`/api/problems/${created.id}`)
+        .send({ priority: 10000 });
+      
+      expect(response.status).toBe(200);
+      expect(response.body.priority).toBe(10000);
     });
   });
 

--- a/backend/src/api/problems.ts
+++ b/backend/src/api/problems.ts
@@ -208,9 +208,12 @@ router.patch('/:id', async (req: Request, res: Response) => {
     }
     
     if (priority !== undefined) {
-      if (typeof priority !== 'number' || priority < 0 || priority > 1000) {
+      if (typeof priority !== 'number') {
+        return res.status(400).json({ error: 'Priority must be a number' });
+      }
+      if (priority < 0 || priority > 10000) {
         return res.status(400).json({ 
-          error: 'Priority must be a number between 0 and 1000' 
+          error: 'Priority must be a number between 0 and 10000' 
         });
       }
     }

--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -391,6 +391,32 @@ describe('Workspaces API', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Invalid status value');
     });
+
+    it('should reject priority greater than 10000', async () => {
+      const response = await request(app)
+        .post(`/api/workspaces/${workspaceId}/problems`)
+        .send({
+          problem: JSON.stringify({ summary: 'Test', detail: '' }),
+          objective: JSON.stringify({ summary: 'Test', detail: '' }),
+          priority: 10001,
+        });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Priority must be a number between 0 and 10000');
+    });
+
+    it('should accept priority up to 10000', async () => {
+      const response = await request(app)
+        .post(`/api/workspaces/${workspaceId}/problems`)
+        .send({
+          problem: JSON.stringify({ summary: 'Test', detail: '' }),
+          objective: JSON.stringify({ summary: 'Test', detail: '' }),
+          priority: 10000,
+        });
+      
+      expect(response.status).toBe(201);
+      expect(response.body.priority).toBe(10000);
+    });
   });
 
   describe('PATCH /api/workspaces/:id', () => {

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -244,10 +244,15 @@ router.post('/:workspaceId/problems', async (req: Request, res: Response) => {
     }
     
     // Validate priority if provided
-    if (priority !== undefined && (typeof priority !== 'number' || priority < 0 || priority > 1000)) {
-      return res.status(400).json({ 
-        error: 'Priority must be a number between 0 and 1000' 
-      });
+    if (priority !== undefined) {
+      if (typeof priority !== 'number') {
+        return res.status(400).json({ error: 'Priority must be a number' });
+      }
+      if (priority < 0 || priority > 10000) {
+        return res.status(400).json({ 
+          error: 'Priority must be a number between 0 and 10000' 
+        });
+      }
     }
     
     // Validate parentId if provided


### PR DESCRIPTION
## Summary
This PR increases the priority validation limit from 1000 to 10000 to support workspaces with more than 1000 sibling problems at the same level.

## Changes
- Updated priority validation in `backend/src/api/problems.ts` and `backend/src/api/workspaces.ts`
- Changed validation limit from 1000 to 10000
- Updated error messages to reflect new limit
- Added test cases for priority > 10000 validation
- Updated test expectations for non-number priority error message

## Testing
- All 81 tests pass
- Added test cases for:
  - Rejecting priority > 10000
  - Accepting priority = 10000
  - Proper error messages for non-number priority

## Impact
This allows workspaces to support up to 10,001 sibling problems at the same level (priorities 0-10000).