### PR TITLE
Implement JavaScript-based column width control for problems table

### DIFF
--- a/frontend/src/components/ProblemsList.tsx
+++ b/frontend/src/components/ProblemsList.tsx
@@ -6,7 +6,7 @@
  * all its children move with it.
  */
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback, RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Problem, Status, CreateProblemRequest, ViewFilters } from '../../../shared/types';
@@ -19,6 +19,141 @@ import { ListCell } from './ListCell';
 import { StatusFilter } from './StatusFilter';
 import { LabelFilter } from './LabelFilter';
 import { LabelCell } from './LabelCell';
+
+// Type for visible columns configuration
+type VisibleColumns = {
+  labels: boolean;
+  objective: boolean;
+  keyResults: boolean;
+  actions: boolean;
+  blockers: boolean;
+  status: boolean;
+  votes: boolean;
+};
+
+// Hook to calculate column widths based on container size and visible columns
+function useColumnWidths(
+  containerRef: RefObject<HTMLDivElement>,
+  visibleColumns: VisibleColumns
+): Record<string, number> {
+  const [widths, setWidths] = useState<Record<string, number>>({});
+
+  const calculateWidths = useCallback(() => {
+    const containerWidth = containerRef.current?.clientWidth ?? 0;
+    if (containerWidth === 0) return;
+
+    // Fixed column widths (never change)
+    const fixed = {
+      rowNumber: 40,
+      id: 80,
+      votes: 65,
+      status: 100,
+    };
+
+    // Minimum widths for flexible columns
+    const minWidths = {
+      problem: 250,  // Must fit all header buttons (PROBLEM + 8 toggle buttons)
+      labels: 60,
+      objective: 80,
+      keyResults: 90,
+      actions: 60,
+      blockers: 70,
+    };
+
+    // Shares for proportional distribution
+    // Problem gets 2 shares which should give it enough extra space for all buttons
+    const shares = {
+      problem: 2,
+      labels: 0.25,
+      objective: 2,
+      keyResults: 1,
+      actions: 1,
+      blockers: 1,
+    };
+
+    // Calculate total fixed width (always-visible + conditionally visible fixed columns)
+    const fixedTotal =
+      fixed.rowNumber +
+      fixed.id +
+      (visibleColumns.votes ? fixed.votes : 0) +
+      (visibleColumns.status ? fixed.status : 0);
+
+    // Calculate total shares and minimum widths for visible flexible columns
+    let totalShares = shares.problem; // Problem is always visible
+    let totalMinWidth = minWidths.problem;
+
+    if (visibleColumns.labels) {
+      totalShares += shares.labels;
+      totalMinWidth += minWidths.labels;
+    }
+    if (visibleColumns.objective) {
+      totalShares += shares.objective;
+      totalMinWidth += minWidths.objective;
+    }
+    if (visibleColumns.keyResults) {
+      totalShares += shares.keyResults;
+      totalMinWidth += minWidths.keyResults;
+    }
+    if (visibleColumns.actions) {
+      totalShares += shares.actions;
+      totalMinWidth += minWidths.actions;
+    }
+    if (visibleColumns.blockers) {
+      totalShares += shares.blockers;
+      totalMinWidth += minWidths.blockers;
+    }
+
+    // Available space for flexible columns
+    const availableSpace = containerWidth - fixedTotal;
+
+    // Space remaining after minimum widths are satisfied
+    const extraSpace = Math.max(0, availableSpace - totalMinWidth);
+
+    // Calculate each flexible column's width
+    const calculateFlexWidth = (column: keyof typeof shares) => {
+      const min = minWidths[column];
+      const share = shares[column];
+      // Each column gets its minimum + proportional share of extra space
+      return Math.floor(min + (extraSpace * share) / totalShares);
+    };
+
+    // Set all widths
+    setWidths({
+      rowNumber: fixed.rowNumber,
+      id: fixed.id,
+      votes: fixed.votes,
+      status: fixed.status,
+      problem: calculateFlexWidth('problem'),
+      labels: visibleColumns.labels ? calculateFlexWidth('labels') : 0,
+      objective: visibleColumns.objective ? calculateFlexWidth('objective') : 0,
+      keyResults: visibleColumns.keyResults ? calculateFlexWidth('keyResults') : 0,
+      actions: visibleColumns.actions ? calculateFlexWidth('actions') : 0,
+      blockers: visibleColumns.blockers ? calculateFlexWidth('blockers') : 0,
+    });
+  }, [containerRef, visibleColumns]);
+
+  useEffect(() => {
+    // Initial calculation
+    calculateWidths();
+
+    // Recalculate on resize
+    const handleResize = () => calculateWidths();
+    window.addEventListener('resize', handleResize);
+
+    // Also observe the container for size changes (e.g., sidebar toggle)
+    const resizeObserver = new ResizeObserver(handleResize);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
+    };
+  }, [calculateWidths, containerRef]);
+
+  return widths;
+}
 
 interface ProblemsListProps {
   workspaceId: string;
@@ -58,6 +193,9 @@ export function ProblemsList({
   
   // Ref to track problem rows for scrolling
   const problemRowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  
+  // Ref for table container (for measuring width)
+  const tableContainerRef = useRef<HTMLDivElement>(null);
   
   // Search/filter state - use external search if provided, otherwise use local state
   const [localSearchQuery] = useState<string>('');
@@ -144,6 +282,9 @@ export function ProblemsList({
     }
     return { labels: true, objective: true, keyResults: true, actions: true, blockers: true, status: true, votes: true };
   });
+
+  // Calculate column widths based on container size and visible columns
+  const columnWidths = useColumnWidths(tableContainerRef, visibleColumns);
 
   // Status filter state - use viewFilters if provided, otherwise fallback to localStorage
   const [selectedStatuses, setSelectedStatuses] = useState<Set<Status>>(() => {
@@ -1567,17 +1708,17 @@ export function ProblemsList({
         </>,
         document.body
       )}
-      <div className="table-container">
+      <div className="table-container" ref={tableContainerRef}>
         <table className="problems-table" data-tutorial="problems-table">
           <thead data-tutorial="problems-table-header">
             <tr>
-              <th className="column-row-number" title={`${visibleProblems.length} visible rows / ${problems.length} total rows`}>
+              <th className="column-row-number" style={{ width: columnWidths.rowNumber }} title={`${visibleProblems.length} visible rows / ${problems.length} total rows`}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: '1.2' }}>
                   <span>{visibleProblems.length}</span>
                   <span className="total-count">{problems.length}</span>
                 </div>
               </th>
-              <th className="column-id">
+              <th className="column-id" style={{ width: columnWidths.id }}>
                 <div className="header-with-action">
                   <span>ID</span>
                   {anyProblemsHaveChildren && (
@@ -1640,7 +1781,7 @@ export function ProblemsList({
                   )}
                 </div>
               </th>
-              <th className="column-problem" style={{ paddingLeft: 0 }}>
+              <th className="column-problem" style={{ width: columnWidths.problem, paddingLeft: 0 }}>
                 <div className="header-with-action" style={{ justifyContent: 'space-between' }}>
                   <div className="header-with-action">
                     <span>Problem</span>
@@ -1715,7 +1856,7 @@ export function ProblemsList({
                 </div>
               </th>
               {visibleColumns.votes && (
-                <th className="column-votes">
+                <th className="column-votes" style={{ width: columnWidths.votes }}>
                   <div className="header-with-action">
                     <button
                       ref={voteFilterButtonRef}
@@ -1730,7 +1871,7 @@ export function ProblemsList({
                 </th>
               )}
               {visibleColumns.labels && (
-                <th className="column-labels">
+                <th className="column-labels" style={{ width: columnWidths.labels }}>
                   <div className="header-with-action">
                     <span>Labels</span>
                     <LabelFilter
@@ -1741,12 +1882,12 @@ export function ProblemsList({
                   </div>
                 </th>
               )}
-              {visibleColumns.objective && <th className="column-objective">Objective</th>}
-              {visibleColumns.keyResults && <th className="column-key-results">Key Results</th>}
-              {visibleColumns.actions && <th className="column-actions">Actions</th>}
-              {visibleColumns.blockers && <th className="column-blockers">Blockers</th>}
+              {visibleColumns.objective && <th className="column-objective" style={{ width: columnWidths.objective }}>Objective</th>}
+              {visibleColumns.keyResults && <th className="column-key-results" style={{ width: columnWidths.keyResults }}>Key Results</th>}
+              {visibleColumns.actions && <th className="column-actions" style={{ width: columnWidths.actions }}>Actions</th>}
+              {visibleColumns.blockers && <th className="column-blockers" style={{ width: columnWidths.blockers }}>Blockers</th>}
               {visibleColumns.status && (
-                <th className="column-status">
+                <th className="column-status" style={{ width: columnWidths.status }}>
                   <div className="header-with-action">
                     <span>Status</span>
                     <StatusFilter

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1238,18 +1238,23 @@ code {
 
 .problems-table th.column-id,
 .problems-table td.column-id { 
-  width: 120px;
+  width: 80px;
 }  /* ID - fixed width */
 
 .problems-table th.column-problem,
 .problems-table td.column-problem { 
-  width: 200px;
-  min-width: 150px;
+  width: 250px;
+  min-width: 250px;
 } /* Problem - fixed reasonable width to prevent wasting space */
+
+.problems-table th.column-votes,
+.problems-table td.column-votes { 
+  width: 65px;
+}  /* Votes - fixed small width */
 
 .problems-table th.column-labels,
 .problems-table td.column-labels { 
-  width: 120px;
+  width: auto;
   min-width: 100px;
 } /* Labels - fixed medium width */
 
@@ -1283,11 +1288,6 @@ code {
   min-width: 90px;
   white-space: nowrap;
 }  /* Status - fixed width for dropdown */
-
-.problems-table th.column-votes,
-.problems-table td.column-votes { 
-  width: 60px;
-}  /* Votes - fixed small width */
 
 .problem-votes {
   text-align: center;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -311,7 +311,7 @@ code {
   border-collapse: collapse;
   background-color: var(--bg-primary);
   font-size: 0.75rem;
-  table-layout: fixed;
+  table-layout: fixed; /* JS calculates widths, fixed ensures content wraps */
   position: relative;
 }
 
@@ -1229,65 +1229,28 @@ code {
   overflow-wrap: break-word;
 }
 
-/* Column widths - apply to both th and td using class-based selectors */
-/* Using fixed pixel widths for small columns and flexible widths for content columns */
-.problems-table th.column-row-number,
-.problems-table td.column-row-number { 
-  width: 40px;
-}  /* Row number - small fixed width */
+/* Column widths are calculated and applied via JavaScript in ProblemsList.tsx
+ * This allows precise control over:
+ * - Fixed columns (row-number, ID, votes, status) with exact pixel widths
+ * - Flexible columns with proportional distribution and minimum widths
+ * 
+ * The JS hook useColumnWidths calculates widths based on container size,
+ * visible columns, and the share/minimum configuration.
+ */
 
-.problems-table th.column-id,
-.problems-table td.column-id { 
-  width: 80px;
-}  /* ID - fixed width */
+/* Column-specific styles (no width declarations - handled by JS) */
 
-.problems-table th.column-problem,
-.problems-table td.column-problem { 
-  width: 250px;
-  min-width: 250px;
-} /* Problem - fixed reasonable width to prevent wasting space */
-
-.problems-table th.column-votes,
-.problems-table td.column-votes { 
-  width: 65px;
-}  /* Votes - fixed small width */
-
-.problems-table th.column-labels,
-.problems-table td.column-labels { 
-  width: auto;
-  min-width: 100px;
-} /* Labels - fixed medium width */
-
-.problems-table th.column-objective,
-.problems-table td.column-objective { 
-  width: 150px;
-  min-width: 120px;
-} /* Objective - fixed medium width */
-
-.problems-table th.column-key-results,
-.problems-table td.column-key-results { 
-  width: auto;
-  min-width: 180px;
-} /* Key Results - flexible width, gets remaining space */
-
-.problems-table th.column-actions,
-.problems-table td.column-actions { 
-  width: auto;
-  min-width: 180px;
-} /* Actions - flexible width, gets remaining space */
-
-.problems-table th.column-blockers,
-.problems-table td.column-blockers { 
-  width: auto;
-  min-width: 180px;
-} /* Blockers - flexible width, gets remaining space */
+/* Problem column header needs overflow visible to show all toggle buttons */
+.problems-table th.column-problem {
+  overflow: visible;
+  position: relative;
+  z-index: 1; /* Ensure toggle buttons aren't covered by adjacent columns */
+}
 
 .problems-table th.column-status,
 .problems-table td.column-status { 
-  width: 100px;
-  min-width: 90px;
   white-space: nowrap;
-}  /* Status - fixed width for dropdown */
+}
 
 .problem-votes {
   text-align: center;


### PR DESCRIPTION
Replace CSS-only column sizing with a JavaScript hook that calculates
widths dynamically based on container size and visible columns.

Changes:
- Add useColumnWidths hook that calculates column widths based on:
  - Fixed columns: row-number (40px), ID (80px), votes (65px), status (100px)
  - Flexible columns with proportional shares:
    - problem: 2 shares, min 250px
    - objective: 2 shares
    - key_results, actions, blockers: 1 share each
    - labels: 0.25 shares (smallest)
  - Each column gets minimum + proportional share of extra space

- Update CSS:
  - Use table-layout: fixed for predictable rendering
  - Remove all explicit column width declarations
  - Add overflow: visible + z-index to Problem header for toggle buttons

- Apply calculated widths as inline styles on th elements
- Use ResizeObserver to recalculate on container size changes

Benefits:
- Fixed columns never stretch or shrink
- Problem column header buttons always visible (250px minimum)
- Labels column stays narrow (0.25 share)
- Long text wraps within calculated column widths
- Responsive to window and container resize